### PR TITLE
add save measurements feature 

### DIFF
--- a/force_torque_sensor_calib/config/dumbo_left_arm_ft_calib.yaml
+++ b/force_torque_sensor_calib/config/dumbo_left_arm_ft_calib.yaml
@@ -2,7 +2,7 @@
 loop_rate: 650.0
 
 # waiting time after moving to each pose before taking F/T measurements
-wait_time: 2.0
+wait_time: 4.0
 
 # Name of the moveit group
 moveit_group_name: 'left_arm'

--- a/force_torque_sensor_calib/config/dumbo_left_arm_ft_calib.yaml
+++ b/force_torque_sensor_calib/config/dumbo_left_arm_ft_calib.yaml
@@ -13,11 +13,17 @@ calib_file_name: 'dumbo_left_arm_ft_calib_data.yaml'
 # Name of the directory
 calib_file_dir: '~/.ros/ft_calib'
 
+# Name of file to store measurements
+meas_file_name: 'dumbo_left_arm_ft_calib_meas.txt'
+
+# Name of the directory
+meas_file_dir: '~/.ros/ft_calib'
+
 # don't execute random poses
-random_poses: false
+random_poses: true
 
 # number of random poses
-number_random_poses: 0
+number_random_poses: 100
 
 # the poses to which to move the arm in order to calibrate the F/T sensor
 # format: [x y z r p y]  in meters, radians

--- a/force_torque_sensor_calib/config/dumbo_right_arm_ft_calib.yaml
+++ b/force_torque_sensor_calib/config/dumbo_right_arm_ft_calib.yaml
@@ -2,7 +2,7 @@
 loop_rate: 650.0
 
 # waiting time after moving to each pose before taking F/T measurements
-wait_time: 2.0
+wait_time: 4.0
 
 # Name of the moveit group
 moveit_group_name: 'right_arm'
@@ -13,11 +13,17 @@ calib_file_name: 'dumbo_right_arm_ft_calib_data.yaml'
 # Name of the directory
 calib_file_dir: '~/.ros/ft_calib'
 
+# Name of file to store measurements
+meas_file_name: 'dumbo_right_arm_ft_calib_meas.txt'
+
+# Name of the directory
+meas_file_dir: '~/.ros/ft_calib'
+
 # don't execute random poses
-random_poses: false
+random_poses: true
 
 # number of random poses
-number_random_poses: 0
+number_random_poses: 100
 
 # the poses to which to move the arm in order to calibrate the F/T sensor
 # format: [x y z r p y]  in meters, radians

--- a/force_torque_sensor_calib/config/example_ft_calib_params.yaml
+++ b/force_torque_sensor_calib/config/example_ft_calib_params.yaml
@@ -2,7 +2,7 @@
 loop_rate: 650.0
 
 # waiting time after moving to each pose before taking F/T measurements
-wait_time: 2.0
+wait_time: 4.0
 
 # Name of the moveit group
 moveit_group_name: 'left_arm'
@@ -12,6 +12,12 @@ calib_file_name: 'ft_calib_data.yaml'
 
 # Name of the directory
 calib_file_dir: '~/.ros/ft_calib'
+
+# Name of file to store measurements
+meas_file_name: 'ft_calib_meas.txt'
+
+# Name of the directory
+meas_file_dir: '~/.ros/ft_calib'
 
 # don't execute random poses
 random_poses: false

--- a/force_torque_sensor_calib/include/force_torque_sensor_calib/ft_calib.h
+++ b/force_torque_sensor_calib/include/force_torque_sensor_calib/ft_calib.h
@@ -89,7 +89,7 @@ protected:
 
 	// measurement matrix based on "On-line Rigid Object Recognition and Pose Estimation
 	//  Based on Inertial Parameters", D. Kubus, T. Kroger, F. Wahl, IROS 2008
-	virtual Eigen::MatrixXd GetMeasurementMatrix(const geometry_msgs::Vector3Stamped &gravity);
+    virtual Eigen::MatrixXd getMeasurementMatrix(const geometry_msgs::Vector3Stamped &gravity);
 
 };
 }

--- a/force_torque_sensor_calib/src/ft_calib.cpp
+++ b/force_torque_sensor_calib/src/ft_calib.cpp
@@ -62,7 +62,7 @@ void FTCalib::addMeasurement(const geometry_msgs::Vector3Stamped &gravity,
 
 	m_num_meas++;
 
-	Eigen::MatrixXd h = GetMeasurementMatrix(gravity);
+    Eigen::MatrixXd h = getMeasurementMatrix(gravity);
 	Eigen::VectorXd z = Eigen::Matrix<double, 6, 1>::Zero();
 	z(0) = ft_raw.wrench.force.x;
 	z(1) = ft_raw.wrench.force.y;
@@ -110,7 +110,7 @@ Eigen::VectorXd FTCalib::getCalib()
 }
 
 
-Eigen::MatrixXd FTCalib::GetMeasurementMatrix(const geometry_msgs::Vector3Stamped &gravity)
+Eigen::MatrixXd FTCalib::getMeasurementMatrix(const geometry_msgs::Vector3Stamped &gravity)
 {
 	KDL::Vector w = KDL::Vector::Zero();
 	KDL::Vector alpha = KDL::Vector::Zero();


### PR DESCRIPTION
This feature allows the user to save the force-torque and accelerometer (gravity) measurements used for the calibration so that they can later be used to recalculate the sensor parameters in a postprocessing stage.
