### PR TITLE
added joint position support and increased planning time

### DIFF
--- a/force_torque_sensor_calib/config/example_ft_calib_params.yaml
+++ b/force_torque_sensor_calib/config/example_ft_calib_params.yaml
@@ -25,6 +25,9 @@ random_poses: false
 # number of random poses
 number_random_poses: 0
 
+# use joint positions instead of cartesian poses
+use_joints: false
+
 # the poses to which to move the arm in order to calibrate the F/T sensor
 # format: [x y z r p y]  in meters, radians
 # poses_frame_id sets the frame at which the poses are expressed


### PR DESCRIPTION
As promised, here is the pull request:
I added a very simple form of joint position support. You can now set the bool "use_joints" in the calib_params.yaml to true, when you want to use joints instead of cartesian coordinates. The pose lists will then be interpreted as 6 joints.
