### PR TITLE
Adding bias calibration service

### DIFF
--- a/gravity_compensation/CMakeLists.txt
+++ b/gravity_compensation/CMakeLists.txt
@@ -2,13 +2,13 @@ cmake_minimum_required(VERSION 2.8.3)
 project(gravity_compensation)
 
 
-find_package(catkin REQUIRED COMPONENTS roscpp geometry_msgs sensor_msgs tf tf_conversions eigen_conversions)
+find_package(catkin REQUIRED COMPONENTS roscpp geometry_msgs sensor_msgs tf tf_conversions eigen_conversions std_srvs)
 
 find_package(Boost REQUIRED COMPONENTS thread)
 
 catkin_package(
   DEPENDS eigen
-  CATKIN_DEPENDS geometry_msgs sensor_msgs tf tf_conversions eigen_conversions
+  CATKIN_DEPENDS geometry_msgs sensor_msgs tf tf_conversions eigen_conversions std_srvs
   INCLUDE_DIRS include 
   LIBRARIES gravity_compensation
 )

--- a/gravity_compensation/package.xml
+++ b/gravity_compensation/package.xml
@@ -21,6 +21,7 @@
   <build_depend>tf_conversions</build_depend>
   <build_depend>eigen</build_depend>
   <build_depend>eigen_conversions</build_depend>
+  <build_depend>std_srvs</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>geometry_msgs</run_depend>
@@ -29,5 +30,6 @@
   <run_depend>tf_conversions</run_depend>
   <run_depend>eigen</run_depend>
   <run_depend>eigen_conversions</run_depend>
+  <run_depend>std_srvs</run_depend>
 
 </package>


### PR DESCRIPTION
Added a calibration service (ros service name: '~/calibrate_bias' ) for calibrating bias in the Force-torque sensor
